### PR TITLE
Fix 'should have a name' test

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -1,8 +1,8 @@
 class Player {
-	construtor(name) {
+	constructor(name) {
 		this.name = name;
-		this.currentScore = currentScore || 0;
-		this.totalScore = totalScore || 0;
+		this.currentScore = 0;
+		this.totalScore = 0;
 	}
 }
 

--- a/test/player-test.js
+++ b/test/player-test.js
@@ -1,19 +1,23 @@
 import chai from 'chai';
 import Player from '../src/player.js';
+// const Player = require('../src/player.js')
 const expect = chai.expect;
 
 describe('Player', function() {
 	let player;
 	beforeEach(() => { 
-		player = new Player('Bob');
-	})
+    player = new Player('Bob');
+  });
+  
   it('should return true', function() {
     expect(true).to.equal(true);
   });
+
   it ('should be a function', function() {
   	expect(Player).to.be.a('function');
-  })
+  });
+
   it('should have a name', function() {
   	expect(player.name).to.equal('Bob')
-  })
+  });
 });


### PR DESCRIPTION
@SamuelColeman Found the reason why we couldn't test 'should have a name', we misspelled 'constructor'. All test pass now.