### PR TITLE
Add tests for round that almost work

### DIFF
--- a/src/turn.js
+++ b/src/turn.js
@@ -62,7 +62,6 @@ class Turn {
   }
 
   solvePuzzle(guess) {
-    console.log(this.currentPuzzle)
     if (guess.toUpperCase() === this.puzzle.correct_answer.toUpperCase()) {
       this.player.updateGameScore(this.player.roundScore);
       $(`.letter`).removeClass('hidden');

--- a/test/turn-test.js
+++ b/test/turn-test.js
@@ -1,10 +1,16 @@
+import $ from 'jquery';
 import chai from 'chai';
 import Turn from '../src/turn.js';
 import Player from '../src/player.js';
 import data from '../src/data.js';
+import domUpdates from '../src/domUpdates.js';
 import Round from '../src/round.js';
 import Game from '../src/game.js';
 const expect = chai.expect;
+const spies = require('chai-spies');
+chai.use(spies);
+global.domUpdates = {};
+chai.spy.on(domUpdates, ['enableConsonants', 'toggleButton', 'changeCurrentPlayer'], () => {});
 
 describe('Turn', function () {
   let player1, player2, player3;
@@ -28,19 +34,35 @@ describe('Turn', function () {
     expect(Turn).to.be.a('function');
   });
 
-  // it('should be able to buy vowel', () => {
-  //   turn.player.currentScore += 200;
-  //   expect(turn.buyVowel('a')).to.equal(true);
-  //   expect(turn.buyVowel('e')).to.equal(false);
-  // });
+  // it('should be able to spin wheel', () => {
 
-  // it('should be able to guess consonant', () => {
-  //   expect(turn.guessConsonant('m')).to.equal(true);
-  //   expect(turn.guessConsonant('z')).to.equal(false);
-  // });
+  // })
 
-  // it('should be able to solve the puzzle', () => {
-  //   expect(turn.solvePuzzle('armchair')).to.equal(true);
-  //   expect(turn.solvePuzzle('legchair')).to.equal(false);
-  // });
+  it('should be able to guess consonant', () => {
+    turn.player.roundScore += 200;
+    expect(turn.guessConsonant('m')).to.equal(true);
+    turn.guessConsonant('r');
+    expect(domUpdates.appendPlayerInfo).to.have.been.called.with([turn.player1]);
+    expect(domUpdates.toggleButton).to.have.been.called(1);   
+    expect(turn.guessConsonant('s')).to.equal(false);
+  })
+
+  it('should be able to buy vowel', () => {
+    turn.player.roundScore += 200;
+    turn.buyVowel('a');
+    expect(domUpdates.appendPlayerInfo).to.have.been.called.with([turn.player1]);
+    expect(turn.player.roundScore).to.equal(100);
+  });
+
+  it('should be able to solve the puzzle', () => {
+    expect(turn.solvePuzzle('armchair')).to.equal(true);
+    expect(turn.solvePuzzle('legchair')).to.equal(false);
+  });
+
+  it('should be able to end turn', () => {
+    turn.endTurn();
+    expect(domUpdates.toggleButton).to.have.been.called(2);
+    expect(domUpdates.changeCurrentPlayer).to.have.been.called(2);
+    expect(turn.round.currentPlayer).to.equal(1)
+  })
 });


### PR DESCRIPTION
Co-authored-by: Eduardo Rodriguez <jeduardorjx@gmail.com>
@brittanystoroz @khalidwilliams

We keep getting this error whenever we try to invoke a method in our round testing file that uses spies: "Error: jQuery requires a window with a document". We have set up the exact same way for our game testing and it is working fine. Do you have any ideas what we're doing wrong?